### PR TITLE
Fix (?) for issue with accessibility page

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -11,6 +11,7 @@
     "src/pages/previous-speakers-page.html",
     "src/pages/team-page.html",
     "src/pages/faq-page.html",
+    "src/pages/accessibility-page.html",
     "src/pages/imprint-page.html",
     "src/pages/privacy-page.html",
     "src/pages/violation-reporting-page.html",


### PR DESCRIPTION
To fix #42 I added the accessibility page to polymer.json - where you find the other pages as well.

A local simulation (run build:prod and used http-server proxying unknown pages to the published page) was successful but really only a stupid simulation.

It's a bit try-and-error, for a complete test of these phenomena we would have to setup a second Firebase project for this.